### PR TITLE
Bump Jinja2 from 2.10 to 2.10.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ decorator==4.3.0
 feedparser==5.2.1
 Flask==1.0.2
 itsdangerous==0.24
-Jinja2==2.10
+Jinja2==2.10.1
 MarkupSafe==1.0
 six==1.11.0
 validators==0.12.2


### PR DESCRIPTION
Due to a security issue within Jinja we should upgrade asap. Tests were completed successfully.