### PR TITLE
Update dependencies for Python 3.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 click==7.1.2
 decorator==4.4.2
-feedparser==5.2.1
+feedparser==6.0.8
 Flask==1.0.2
 itsdangerous==0.24
 Jinja2==2.11.3
-MarkupSafe==1.0
+MarkupSafe==2.0.1
 six==1.11.0
 validators==0.12.6
 Werkzeug==0.15.3


### PR DESCRIPTION
The pinned versions for feedparser/MarkupSafe did not work with Alpine and Python 3.9